### PR TITLE
Use standard Tempfile naming to avoid Sprockets conflict

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,13 +1,3 @@
-require 'tempfile'
-
-Tempfile.class_eval do
-  # overwrite so tempfiles use the extension of the basename. important for rmagick and image science
-  def make_tmpname(basename, n)
-    ext = nil
-    sprintf("%s%d-%d%s", basename.to_s.gsub(/\.\w+$/) { |s| ext = s; '' }, $$, n.to_i, ext)
-  end
-end
-
 require 'geometry'
 ActiveRecord::Base.send(:extend, Technoweenie::AttachmentFu::ActMethods)
 Technoweenie::AttachmentFu.tempfile_path = ATTACHMENT_FU_TEMPFILE_PATH if Object.const_defined?(:ATTACHMENT_FU_TEMPFILE_PATH)

--- a/lib/pothoven-attachment_fu.rb
+++ b/lib/pothoven-attachment_fu.rb
@@ -3,21 +3,10 @@ class Engine < Rails::Engine
   config.autoload_paths << File.expand_path("..", __FILE__)
 
   initializer "attachment_fu" do
-    require 'tempfile'
     require 'geometry'
 
     ActiveRecord::Base.send(:extend, Technoweenie::AttachmentFu::ActMethods)
     Technoweenie::AttachmentFu.tempfile_path = ATTACHMENT_FU_TEMPFILE_PATH if Object.const_defined?(:ATTACHMENT_FU_TEMPFILE_PATH)
     FileUtils.mkdir_p Technoweenie::AttachmentFu.tempfile_path
-
-    # overwrite so tempfiles use the extension of the basename.
-    # important for rmagick and image science
-    Tempfile.class_eval do
-      def make_tmpname(basename, n)
-        ext = nil
-        sprintf("%s%d-%d%s", basename.to_s.gsub(/\.\w+$/) { |s| ext = s; '' }, $$, n.to_i, ext)
-      end
-    end
-
   end
 end

--- a/lib/technoweenie/attachment_fu.rb
+++ b/lib/technoweenie/attachment_fu.rb
@@ -425,7 +425,9 @@ module Technoweenie # :nodoc:
       protected
         # Generates a unique filename for a Tempfile.
         def random_tempfile_filename
-          "#{rand Time.now.to_i}#{filename || 'attachment'}"
+          base_filename = filename ? filename.gsub(/\.\w+$/, '') : 'attachment'
+          ext = filename.slice(/\.\w+$/)
+          ["#{rand Time.now.to_i}#{base_filename}", ext || '']
         end
 
         def sanitize_filename(filename)


### PR DESCRIPTION
First off, many thanks for turning this into a gem, you've saved us a lot of time and headache. 

Regarding my changes- assuming that everything in https://github.com/rails/rails/issues/6989 is accurate, the monkey patch that Attachment Fu makes on `Tempfile` conflicts with Sprockets and causes the sporadic error I've been trying to track down. Fortunately, Ruby 1.8.7+ has its own mechanism for retaining file extensions when naming temporary files. I've removed the monkey patch and tweaked `random_tempfile_filename` to return an array as per the newer Tempfile initializer. 

In the interest of full disclosure I was not able to get the test suite running in full prior to making my changes (lots of dependencies, and it still thinks it's a plugin?), but have not encountered any issues thus far. 
