### PR TITLE
Stops create_or_update_thumbnail from using without_protection on all...

### DIFF
--- a/lib/technoweenie/attachment_fu.rb
+++ b/lib/technoweenie/attachment_fu.rb
@@ -483,6 +483,7 @@ module Technoweenie # :nodoc:
             respond_to?(:parent_id) ?
               thumbnail_class.find_or_initialize_by_thumbnail_and_parent_id(file_name_suffix.to_s, id) :
               thumbnail_class.find_or_initialize_by_thumbnail(file_name_suffix.to_s)
+          end
         end
 
         # Stub for a #process_attachment method in a processor


### PR DESCRIPTION
...rails versions except for major release number 3

This was creating an exception with active record for too many args on rails 4.

The second commit fixes a deprecation warning around how Rails 4 handles find_or_initialize_by.
