### PR TITLE
Refactor DbFileBackend for Rails 4 AREL conformity

### DIFF
--- a/lib/technoweenie/attachment_fu/backends/db_file_backend.rb
+++ b/lib/technoweenie/attachment_fu/backends/db_file_backend.rb
@@ -30,7 +30,7 @@ module Technoweenie # :nodoc:
               (db_file || build_db_file).data = temp_data
               db_file.save!
               self.db_file_id = db_file.id
-              self.class.where(id: id).update_all(db_file_id: db_file.id)
+              self.class.where(:id => id).update_all(:db_file_id => db_file.id)
             end
             true
           end


### PR DESCRIPTION
ActiveRecord#update_all was deprecated in Rails 2.3.8 and has since been replaced by ActiveRecord::Relation#update_all.  With this change the method signature (accepted parameters) and usage have also changed requiring the refactoring.

Without the modification, users in later versions of Rails (myself in 4.1) with an ActiveRecord model wrapped by attachement_fu indicating the storage type of :db_file  will receive a "wrong number of arguments (2 for 1)" error when attempting to save/persist the model.
