### PR TITLE
Replace aws-s3 gem with aws-sdk-v1.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ group :test, :development do
   gem 'rmagick'
   gem 'core_image'
   gem 'mini_magick'
-  gem 'aws-s3', :require => 'aws/s3'
+  gem 'aws-sdk-v1', '~> 1.61.0'
   gem 'test-unit'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,10 +34,9 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     arel (3.0.2)
-    aws-s3 (0.6.3)
-      builder
-      mime-types
-      xml-simple
+    aws-sdk-v1 (1.61.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
     builder (3.0.4)
     core_image (0.0.3.5)
     erubis (2.7.0)
@@ -51,7 +50,10 @@ GEM
     mime-types (1.24)
     mini_magick (3.6.0)
       subexec (~> 0.2.1)
+    mini_portile (0.6.2)
     multi_json (1.7.9)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     polyglot (0.3.3)
     rack (1.4.5)
     rack-cache (1.2)
@@ -93,13 +95,12 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.37)
-    xml-simple (1.1.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-s3
+  aws-sdk-v1 (~> 1.61.0)
   core_image
   mini_magick
   pothoven-attachment_fu!

--- a/attachment_fu.gemspec
+++ b/attachment_fu.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "nowarning"
   s.rubygems_version  = %q{1.8.29}
 
+  s.add_runtime_dependency 'aws-sdk-v1', '~> 1.61.0'
+
   if s.respond_to? :specification_version then
     s.specification_version = 2
   end

--- a/attachment_fu.gemspec
+++ b/attachment_fu.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "nowarning"
   s.rubygems_version  = %q{1.8.29}
 
-  s.add_runtime_dependency 'aws-sdk-v1', '~> 1.61.0'
+  s.requirements << 'aws-sdk-v1, ~> 1.61.0'
 
   if s.respond_to? :specification_version then
     s.specification_version = 2

--- a/lib/technoweenie/attachment_fu/backends/s3_backend.rb
+++ b/lib/technoweenie/attachment_fu/backends/s3_backend.rb
@@ -7,8 +7,7 @@ module Technoweenie # :nodoc:
       #
       # == Requirements
       #
-      # Requires the {AWS::S3 Library}[http://amazon.rubyforge.org] for S3 by Marcel Molina Jr. installed either
-      # as a gem or a as a Rails plugin.
+      # Requires the aws-sdk-v1 gem.
       #
       # == Configuration
       #
@@ -173,11 +172,10 @@ module Technoweenie # :nodoc:
         class ConfigFileNotFoundError < StandardError; end
 
         def self.included(base) #:nodoc:
-          mattr_reader :bucket_name, :s3_config
+          mattr_reader :bucket_name, :s3_config, :s3_conn, :bucket
 
           begin
-            require 'aws/s3'
-            include AWS::S3
+            require 'aws-sdk-v1'
           rescue LoadError
             raise RequiredLibraryNotFoundError.new('AWS::S3 could not be loaded')
           end
@@ -198,9 +196,10 @@ module Technoweenie # :nodoc:
           end
           base.class_eval(eval_string, __FILE__, __LINE__)
 
-          Base.establish_connection!(s3_config.slice(:access_key_id, :secret_access_key, :server, :port, :use_ssl, :persistent, :proxy))
+          @@s3_conn = AWS::S3.new(s3_config.slice(:access_key_id, :secret_access_key))
+          @@bucket = s3_conn.buckets[s3_config[:bucket_name]]
 
-          # Bucket.create(@@bucket_name)
+          #Base.establish_connection!(s3_config.slice(:access_key_id, :secret_access_key, :server, :port, :use_ssl, :persistent, :proxy))
 
           base.before_update :rename_file
         end
@@ -210,7 +209,7 @@ module Technoweenie # :nodoc:
         end
 
         def self.hostname
-          @hostname ||= s3_config[:server] || AWS::S3::DEFAULT_HOST
+          @hostname ||= s3_config[:server] || 's3.amazonaws.com'
         end
 
         def self.port_string
@@ -324,9 +323,12 @@ module Technoweenie # :nodoc:
         #   @photo.authenticated_s3_url('thumbnail', :expires_in => 5.hours, :use_ssl => true)
         def authenticated_s3_url(*args)
           options   = args.extract_options!
-          options[:expires_in] = options[:expires_in].to_i if options[:expires_in]
+          options[:expires] = options[:expires_in].to_i if options[:expires_in]
+          options[:secure] = options[:use_ssl] if options[:use_ssl]
+          options.delete(:expires_in) if options[:expires_in]
+          options.delete(:use_ssl) if options[:use_ssl]
           thumbnail = args.shift
-          S3Object.url_for(full_filename(thumbnail), bucket_name, options)
+          bucket.objects[full_filename(thumbnail)].url_for(:read, options).to_s
         end
 
         def create_temp_file
@@ -335,9 +337,9 @@ module Technoweenie # :nodoc:
 
         def current_data
           if attachment_options[:encrypted_storage] && self.respond_to?(:encryption_key) && self.encryption_key != nil
-            EncryptedData.decrypt_data(S3Object.value(full_filename, bucket_name), self.encryption_key)
+            EncryptedData.decrypt_data(bucket.objects[full_filename].read, self.encryption_key)
           else
-            S3Object.value full_filename, bucket_name
+            bucket.objects[full_filename].read
           end
         end
 
@@ -360,21 +362,28 @@ module Technoweenie # :nodoc:
         protected
           # Called in the after_destroy callback
           def destroy_file
-            S3Object.delete full_filename, bucket_name
+            obj = bucket.objects[full_filename]
+            obj.delete
           end
 
           def rename_file
             return unless @old_filename && @old_filename != filename
 
             old_full_filename = File.join(base_path, @old_filename)
+            old_obj = bucket.objects[old_full_filename]
+            obj = bucket.objects[full_filename]
 
-            S3Object.rename(
-              old_full_filename,
-              full_filename,
-              bucket_name,
-              :access => attachment_options[:s3_access]
-            )
+            if attachment_options[:encrypted_storage]
+              obj.copy_from(old_obj, {:cache_control => attachment_options[:cache_control],
+                                      :acl => attachment_options[:s3_access],
+                                      :server_side_encryption => :aes256,
+                                      :content_disposition => "attachment; filename=\"#{filename}\""})
+            else
+              obj.copy_from(old_obj, {:cache_control => attachment_options[:cache_control],
+                                      :acl => attachment_options[:s3_access]})
+            end
 
+            old_obj.delete
             @old_filename = nil
             true
           end
@@ -382,25 +391,19 @@ module Technoweenie # :nodoc:
           def save_to_storage
             if save_attachment?
               if attachment_options[:encrypted_storage]
-                S3Object.store(
-                               full_filename,
-                               (temp_path ? File.open(temp_path) : temp_data),
-                               bucket_name,
-                               :content_type => content_type,
-                               :cache_control => attachment_options[:cache_control],
-                               :access => attachment_options[:s3_access],
-                               'x-amz-server-side-encryption' => 'AES256',
-                               'Content-Disposition' => "attachment; filename=\"#{filename}\""
-                               )
+                obj = bucket.objects[full_filename]
+                obj.write(:file => (temp_path ? File.open(temp_path) : temp_data),
+                          :cache_control => attachment_options[:cache_control],
+                          :acl => attachment_options[:s3_access],
+                          :server_side_encryption => :aes256,
+                          :content_disposition => "attachment; filename=\"#{filename}\""
+                )
               else
-                S3Object.store(
-                               full_filename,
-                               (temp_path ? File.open(temp_path) : temp_data),
-                               bucket_name,
-                               :content_type => content_type,
-                               :cache_control => attachment_options[:cache_control],
-                               :access => attachment_options[:s3_access]
-                               )
+                obj = bucket.objects[full_filename]
+                obj.write(:file => (temp_path ? File.open(temp_path) : temp_data),
+                          :cache_control => attachment_options[:cache_control],
+                          :acl => attachment_options[:s3_access]
+                )
               end
             end
 

--- a/lib/technoweenie/attachment_fu/backends/s3_backend.rb
+++ b/lib/technoweenie/attachment_fu/backends/s3_backend.rb
@@ -177,7 +177,7 @@ module Technoweenie # :nodoc:
           begin
             require 'aws-sdk-v1'
           rescue LoadError
-            raise RequiredLibraryNotFoundError.new('AWS::S3 could not be loaded')
+            raise RequiredLibraryNotFoundError.new('aws-sdk-v1 could not be loaded. Make sure the gem is installed.')
           end
 
           begin


### PR DESCRIPTION
The aws-s3 gem is no longer being maintained and is out of date. This PR replaces that gem with the first version of aws-sdk built by Amazon. The aws-sdk-v1 gem is used because it is the full production ready version of the aws-sdk available and will not cause issues if aws-sdk version 2 is also loaded on a system (v2 is not backward compatible but can live on the same system as v1). 

A runtime dependency has been added to attachment_fu for aws-sdk-v1 to make installing and using the attachment_fu gem easier out of the box
