### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/technoweenie/attachment_fu/processors/rmagick_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/rmagick_processor.rb
@@ -1,4 +1,5 @@
-require 'RMagick'
+require 'rmagick'
+
 module Technoweenie # :nodoc:
   module AttachmentFu # :nodoc:
     module Processors


### PR DESCRIPTION
Fix `[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead`