### PR TITLE
fix for non-existent #where interface in rails 2.3

### DIFF
--- a/lib/technoweenie/attachment_fu.rb
+++ b/lib/technoweenie/attachment_fu.rb
@@ -477,7 +477,11 @@ module Technoweenie # :nodoc:
         def find_or_initialize_thumbnail(file_name_suffix)
           attrs = {thumbnail: file_name_suffix.to_s}
           attrs[:parent_id] = id if respond_to? :parent_id
-          thumb = thumbnail_class.where(attrs).first
+          thumb = if thumbnail_class.respond_to?(:where)
+                    thumbnail_class.where(attrs).first
+                  else
+                    thumbnail_class.find(:first, :conditions => attrs)
+                  end
           unless thumb
             thumb = thumbnail_class.new
             attrs.each{ |a, v| thumb[a] = v }

--- a/lib/technoweenie/attachment_fu/backends/db_file_backend.rb
+++ b/lib/technoweenie/attachment_fu/backends/db_file_backend.rb
@@ -30,7 +30,12 @@ module Technoweenie # :nodoc:
               (db_file || build_db_file).data = temp_data
               db_file.save!
               self.db_file_id = db_file.id
-              self.class.where(:id => id).update_all(:db_file_id => db_file.id)
+
+              if self.class.respond_to?(:where)
+                self.class.where(:id => id).update_all(:db_file_id => db_file.id)
+              else
+                self.class.update_all({ :db_file_id => db_file.id }, { :id => id })
+              end
             end
             true
           end


### PR DESCRIPTION
Needed to use this in Rails 2.3 where the AREL queries cause issue. Just checking if the object `respond_to?(:where)` and handling accordingly.