### PR TITLE
Replace alias_method_chain with alias_method

### DIFF
--- a/lib/technoweenie/attachment_fu/processors/core_image_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/core_image_processor.rb
@@ -6,7 +6,8 @@ module Technoweenie # :nodoc:
       module CoreImageProcessor
         def self.included(base)
           base.send :extend, ClassMethods
-          base.alias_method_chain :process_attachment, :processing
+          base.alias_method :process_attachment_without_processing, :process_attachment
+          base.alias_method :process_attachment, :process_attachment_with_processing
         end
         
         module ClassMethods

--- a/lib/technoweenie/attachment_fu/processors/gd2_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/gd2_processor.rb
@@ -6,7 +6,8 @@ module Technoweenie # :nodoc:
       module Gd2Processor
         def self.included(base)
           base.send :extend, ClassMethods
-          base.alias_method_chain :process_attachment, :processing
+          base.alias_method :process_attachment_without_processing, :process_attachment
+          base.alias_method :process_attachment, :process_attachment_with_processing
         end
         
         module ClassMethods

--- a/lib/technoweenie/attachment_fu/processors/image_science_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/image_science_processor.rb
@@ -5,7 +5,8 @@ module Technoweenie # :nodoc:
       module ImageScienceProcessor
         def self.included(base)
           base.send :extend, ClassMethods
-          base.alias_method_chain :process_attachment, :processing
+          base.alias_method :process_attachment_without_processing, :process_attachment
+          base.alias_method :process_attachment, :process_attachment_with_processing
         end
 
         module ClassMethods

--- a/lib/technoweenie/attachment_fu/processors/mini_magick_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/mini_magick_processor.rb
@@ -5,7 +5,8 @@ module Technoweenie # :nodoc:
       module MiniMagickProcessor
         def self.included(base)
           base.send :extend, ClassMethods
-          base.alias_method_chain :process_attachment, :processing
+          base.alias_method :process_attachment_without_processing, :process_attachment
+          base.alias_method :process_attachment, :process_attachment_with_processing
         end
  
         module ClassMethods

--- a/lib/technoweenie/attachment_fu/processors/rmagick_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/rmagick_processor.rb
@@ -13,7 +13,8 @@ module Technoweenie # :nodoc:
       module RmagickProcessor
         def self.included(base)
           base.send :extend, ClassMethods
-          base.alias_method_chain :process_attachment, :processing
+          base.alias_method :process_attachment_without_processing, :process_attachment
+          base.alias_method :process_attachment, :process_attachment_with_processing
         end
 
         module ClassMethods

--- a/vendor/red_artisan/core_image/processor.rb
+++ b/vendor/red_artisan/core_image/processor.rb
@@ -105,9 +105,10 @@ module OSX
     
       block.call f.valueForKey('outputImage')
     end
-  
-    alias_method_chain :method_missing, :filter_processing
-      
+
+    alias_method :method_missing_without_filter_processing, :method_missing
+    alias_method :method_missing, :method_missing_with_filter_processing
+
     def save(target, format = OSX::NSJPEGFileType, properties = nil)
       bitmapRep = OSX::NSBitmapImageRep.alloc.initWithCIImage(self)
       blob = bitmapRep.representationUsingType_properties(format, properties)


### PR DESCRIPTION
Rails 5 removed `alias_method_chain`, and while `Module#prepend` is the preferred way to go now, using `alias_method` is the easiest refactor.