### PR TITLE
Replace Fixnum with Integer

### DIFF
--- a/lib/technoweenie/attachment_fu/processors/core_image_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/core_image_processor.rb
@@ -30,8 +30,8 @@ module Technoweenie # :nodoc:
           def resize_image(img, size)
             processor = ::RedArtisan::CoreImage::Processor.new(img)
             size = size.first if size.is_a?(Array) && size.length == 1
-            if size.is_a?(Fixnum) || (size.is_a?(Array) && size.first.is_a?(Fixnum))
-              if size.is_a?(Fixnum)
+            if size.is_a?(Integer) || (size.is_a?(Array) && size.first.is_a?(Integer))
+              if size.is_a?(Integer)
                 processor.fit(size)
               else
                 processor.resize(size[0], size[1])

--- a/lib/technoweenie/attachment_fu/processors/gd2_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/gd2_processor.rb
@@ -31,8 +31,8 @@ module Technoweenie # :nodoc:
           # Performs the actual resizing operation for a thumbnail
           def resize_image(img, size)
             size = size.first if size.is_a?(Array) && size.length == 1
-            if size.is_a?(Fixnum) || (size.is_a?(Array) && size.first.is_a?(Fixnum))
-              if size.is_a?(Fixnum)
+            if size.is_a?(Integer) || (size.is_a?(Array) && size.first.is_a?(Integer))
+              if size.is_a?(Integer)
                 # Borrowed from image science's #thumbnail method and adapted 
                 # for this.
                 scale = size.to_f / (img.width > img.height ? img.width.to_f : img.height.to_f)

--- a/lib/technoweenie/attachment_fu/processors/image_science_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/image_science_processor.rb
@@ -52,8 +52,8 @@ module Technoweenie # :nodoc:
             end
 
             size = size.first if size.is_a?(Array) && size.length == 1
-            if size.is_a?(Fixnum) || (size.is_a?(Array) && size.first.is_a?(Fixnum))
-              if size.is_a?(Fixnum)
+            if size.is_a?(Integer) || (size.is_a?(Array) && size.first.is_a?(Integer))
+              if size.is_a?(Integer)
                 img.thumbnail(size, &grab_dimensions)
               else
                 img.resize(size[0], size[1], &grab_dimensions)

--- a/lib/technoweenie/attachment_fu/processors/mini_magick_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/mini_magick_processor.rb
@@ -47,8 +47,8 @@ module Technoweenie # :nodoc:
               img.format('PNG')
             end
             
-            if size.is_a?(Fixnum) || (size.is_a?(Array) && size.first.is_a?(Fixnum))
-              if size.is_a?(Fixnum)
+            if size.is_a?(Integer) || (size.is_a?(Array) && size.first.is_a?(Integer))
+              if size.is_a?(Integer)
                 size = [size, size]
                 commands.resize(size.join('x'))
               else

--- a/lib/technoweenie/attachment_fu/processors/rmagick_processor.rb
+++ b/lib/technoweenie/attachment_fu/processors/rmagick_processor.rb
@@ -47,9 +47,9 @@ module Technoweenie # :nodoc:
 
         # Performs the actual resizing operation for a thumbnail
         def resize_image(img, size)
-          size = size.first if size.is_a?(Array) && size.length == 1 && !size.first.is_a?(Fixnum)
-          if size.is_a?(Fixnum) || (size.is_a?(Array) && size.first.is_a?(Fixnum))
-            size = [size, size] if size.is_a?(Fixnum)
+          size = size.first if size.is_a?(Array) && size.length == 1 && !size.first.is_a?(Integer)
+          if size.is_a?(Integer) || (size.is_a?(Array) && size.first.is_a?(Integer))
+            size = [size, size] if size.is_a?(Integer)
             img.thumbnail!(*size)
           elsif size.is_a?(String) && size =~ /^c.*$/ # Image cropping - example geometry string: c75x75
             dimensions = size[1..size.size].split("x")


### PR DESCRIPTION
Fixes "warning: constant ::Fixnum is deprecated" in Ruby 2.4. This PR is similar to #18 but comes with just the required changes, nothing else. Would be awesome if this can be merged.

@pothoven Sorry that this comes a day after my other PR - you were just too fast with merging ;)